### PR TITLE
Fix: CrashLoopBackOff due to permission error

### DIFF
--- a/Chapter06/fortune/Dockerfile
+++ b/Chapter06/fortune/Dockerfile
@@ -3,5 +3,5 @@ FROM ubuntu:latest
 RUN apt-get update ; apt-get -y install fortune
 ADD fortuneloop.sh /bin/fortuneloop.sh
 
-ENTRYPOINT /bin/fortuneloop.sh
+ENTRYPOINT bash /bin/fortuneloop.sh
 


### PR DESCRIPTION
The script file is copied w/o 'x' perms, so if run like this, the container will refuse to start due to a permission denied error:

`/bin/sh: 1: /bin/fortuneloop.sh: Permission denied`

Adding the 'x' permission or running it with `bash` fixes it.