### PR TITLE
Chapter10: Change apps/v1beta1; Add field "selector"; to make it run on kubernetes 1.18.3

### DIFF
--- a/Chapter10/kubia-statefulset.yaml
+++ b/Chapter10/kubia-statefulset.yaml
@@ -1,10 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kubia
 spec:
   serviceName: kubia
   replicas: 2
+  selector:
+    matchLabels:
+      app: kubia # has to match .spec.template.metadata.labels
   template:
     metadata:
       labels:


### PR DESCRIPTION
Change apps/v1beta1; Add field "selector"; to make it run on kubernetes 1.18.3

There will be errors if we don't make a change:

 [root@master1 Chapter10]# kubectl apply -f kubia-statefulset.yaml
error: unable to recognize "kubia-statefulset.yaml": no matches for kind "StatefulSet" in version "apps/v1beta1"
[root@master1 Chapter10]#

[root@master1 Chapter10]# kubectl apply -f kubia-statefulset.yaml
error: error validating "kubia-statefulset.yaml": error validating data: ValidationError(StatefulSet.spec): missing required field "selector" in io.k8s.api.apps.v1.StatefulSetSpec; if you choose to ign
ore these errors, turn validation off with --validate=false
[root@master1 Chapter10]#