### PR TITLE
fix v1beta1 issues

### DIFF
--- a/Chapter04/kubia-replicaset-matchexpressions.yaml
+++ b/Chapter04/kubia-replicaset-matchexpressions.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: kubia

--- a/Chapter04/kubia-replicaset.yaml
+++ b/Chapter04/kubia-replicaset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: kubia

--- a/Chapter04/ssd-monitor-daemonset.yaml
+++ b/Chapter04/ssd-monitor-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ssd-monitor

--- a/Chapter09/kubia-deployment-and-service-v1.yaml
+++ b/Chapter09/kubia-deployment-and-service-v1.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubia
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: kubia
   template:
     metadata:
       name: kubia

--- a/Chapter09/kubia-deployment-v2.yaml
+++ b/Chapter09/kubia-deployment-v2.yaml
@@ -1,8 +1,11 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubia
 spec:
+  selector:
+    matchLabels:
+      app: kubia
   template:
     metadata:
       name: kubia

--- a/Chapter09/kubia-deployment-v3-with-readinesscheck.yaml
+++ b/Chapter09/kubia-deployment-v3-with-readinesscheck.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubia
@@ -10,6 +10,9 @@ spec:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: kubia
   template:
     metadata:
       name: kubia

--- a/Chapter09/kubia-deployment-v3.yaml
+++ b/Chapter09/kubia-deployment-v3.yaml
@@ -1,10 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubia
 spec:
   replicas: 3
   minReadySeconds: 10
+  selector:
+    matchLabels:
+      app: kubia
   template:
     metadata:
       name: kubia

--- a/Chapter10/kubia-statefulset-peers.yaml
+++ b/Chapter10/kubia-statefulset-peers.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kubia


### PR DESCRIPTION
in some cases, v1beta1 has been deprecated, and it will fail when creating with those file

the `selector` part when creating `Deployment` is copied from #27

```yaml
  selector:
    matchLabels:
      app: kubia
```

