### PR TITLE
add: 'clusterIP: None' for chapter05/kubia-svc-publish-not-ready.yaml

### DIFF
--- a/Chapter05/kubia-svc-publish-not-ready.yaml
+++ b/Chapter05/kubia-svc-publish-not-ready.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: kubia-all
 spec:
+  clusterIP: None
   ports:
   - port: 80
     targetPort: 8080


### PR DESCRIPTION
The `clusterIP: None` is lack in  `chapter05/kubia-svc-publish-not-ready.yaml`；

If you don't add this config, the service is not run in the headless mode.
And then, you can't get all pods's ip. 