### PR TITLE
Add comments at chapter10/kubia-statefulset.yaml

### DIFF
--- a/Chapter10/kubia-statefulset.yaml
+++ b/Chapter10/kubia-statefulset.yaml
@@ -14,20 +14,23 @@ spec:
         app: kubia
     spec:
       containers:
-      - name: kubia
-        image: luksa/kubia-pet
-        ports:
-        - name: http
-          containerPort: 8080
-        volumeMounts:
-        - name: data
-          mountPath: /var/data
+        - name: kubia
+          image: luksa/kubia-pet
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /var/data
   volumeClaimTemplates:
-  - metadata:
-      name: data
-    spec:
-      resources:
-        requests:
-          storage: 1Mi
-      accessModes:
-      - ReadWriteOnce
+    - metadata:
+        name: data
+      spec:
+        resources:
+          requests:
+            storage: 1Mi
+        accessModes:
+          - ReadWriteOnce
+        # If you already created persistent volumes, then
+        # uncomment below field to use existing persistent volumes(disable dynamic provisioning)
+        # storageClassName: ""


### PR DESCRIPTION
If someone created persistent volumes explicitly, they need to set `volumeClaimTemplates.storageClassName` to an empty string(`""`) at statefulset descriptor in order to use existing persistent volumes([reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#:~:text=Claims%20that%20request%20the%20class%20%22%22%20effectively%20disable%20dynamic%20provisioning%20for%20themselves)). 

without this option, new persistent volumes will be created and persistent volume claims instantiated by statefulset will be bound to them(not use `pv-a`, .. but `pvc-eaa0905a...`).

so I simply added comments on statefulset yaml descriptor.